### PR TITLE
Support emoji

### DIFF
--- a/message/manager.php
+++ b/message/manager.php
@@ -129,6 +129,12 @@ class manager
 
 		$action = ($cannedmessage_data['cannedmessage_id'] > 0) ? 'update' : 'insert';
 
+		// Handle emojis in canned message
+		if (!empty($cannedmessage_data['cannedmessage_content']))
+		{
+			$cannedmessage_data['cannedmessage_content'] = utf8_encode_ucr($cannedmessage_data['cannedmessage_content']);
+		}
+
 		if ($error = $this->{$action}($cannedmessage_data))
 		{
 			return $error;

--- a/migrations/emoji_support.php
+++ b/migrations/emoji_support.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *
+ * Canned Messages. An extension for the phpBB Forum Software package.
+ *
+ * @copyright (c) 2017 phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ */
+
+namespace phpbb\cannedmessages\migrations;
+
+class emoji_support extends \phpbb\db\migration\migration
+{
+	public static function depends_on()
+	{
+		return [
+			'\phpbb\cannedmessages\migrations\install_cannedmessages_schema',
+			'\phpbb\cannedmessages\migrations\update_cannedmessages_schema',
+		];
+	}
+
+	public function update_schema()
+	{
+		return [
+			'change_columns'	=> [
+				$this->table_prefix . 'cannedmessages'	=> [
+					'cannedmessage_content'	=> ['MTEXT_UNI', ''],
+				],
+			],
+		];
+	}
+
+	public function revert_schema()
+	{
+	}
+}

--- a/styles/all/template/js/cannedmessages_mcp.js
+++ b/styles/all/template/js/cannedmessages_mcp.js
@@ -30,6 +30,15 @@ text_name = 'cannedmessage_content';
 		$(this).parents('li').remove();
 	});
 
+	// Remove emoji and other non-standard characters from title
+	document.getElementById('cannedmessage_name').addEventListener('input', function(e) {
+		const noEmoji = e.target.value.replace(/[\u{1F300}-\u{1F9FF}]|[\u{2700}-\u{27BF}]|[\u{2600}-\u{26FF}]|[\u{2300}-\u{23FF}]|[\u{1F000}-\u{1F6FF}]|[\u{2B00}-\u{2BFF}]/gu, '');
+
+		if (e.target.value !== noEmoji) {
+			e.target.value = noEmoji;
+		}
+	});
+
 	$(function() {
 		var $add_edit = $('#cannedmessage_add_edit'),
 			$content = $('#cannedmessage_content_section'),

--- a/tests/manager/save_message_test.php
+++ b/tests/manager/save_message_test.php
@@ -30,6 +30,7 @@ class save_message_test extends manager_base
 			array(array_merge($this->get_data_template(), array('is_cat' => 1))), // add new category
 			array(array_merge($this->get_data_template(), array('parent_id' => 1))), // add new message to Category 1
 			array(array_merge($this->get_data_template(), array('parent_id' => 1, 'is_cat' => 1))), // add new category to Category 1
+			array(array_merge($this->get_data_template(), array('cannedmessage_content' => 'Test content 😀'))), // add message with emoji
 		);
 	}
 


### PR DESCRIPTION
Fixes #27

Allows emoji to be used in messages without causing SQL crash. Also uses JS to prevent using emoji in message titles (which cause a crash when trying to log changes to the MCP logs)